### PR TITLE
Add PP-OCRv5 (multilingual OCR: detection + 7 v5 recognizers)

### DIFF
--- a/src/qai_hub_models/models/pp_ocrv5/README.md
+++ b/src/qai_hub_models/models/pp_ocrv5/README.md
@@ -1,0 +1,100 @@
+# [PP-OCRv5: PaddleOCR v5 text detection with recognition for 7 languages for on-device OCR](https://aihub.qualcomm.com/models/pp_ocrv5)
+
+PP-OCRv5 is a multilingual OCR pipeline with a shared text detector and language-specific recognizers. This collection bundles the detector with all seven PP-OCRv5 recognition components — Simplified Chinese (with Japanese coverage), English, Latin-script, Cyrillic / East-Slavic, Korean, Thai, and Greek — for fully on-device optical character recognition.
+
+This is based on the implementation of PP-OCRv5 found [here](https://github.com/PaddlePaddle/PaddleOCR).
+This repository contains scripts for optimized on-device export suitable to run on Qualcomm® devices. More details on model performance across various devices, can be found [here](https://aihub.qualcomm.com/models/pp_ocrv5).
+
+Qualcomm AI Hub Models uses [Qualcomm AI Hub Workbench](https://workbench.aihub.qualcomm.com) to compile, profile, and evaluate this model. [Sign up](https://myaccount.qualcomm.com/signup) to run these models on a hosted Qualcomm® device.
+
+## Components
+
+| Component | Description | Input resolution |
+|-----------|-------------|------------------|
+| `det` | Text detection (PP-HGNetV2 + DB++) | 640x640 |
+| `zh_rec` | Simplified Chinese + English recognition (SVTR/CTC) | 48x320 |
+| `ko_rec` | Korean + English recognition (SVTR/CTC) | 48x320 |
+| `en_rec` | English recognition (SVTR/CTC) | 48x320 |
+| `latin_rec` | Latin-script recognition (SVTR/CTC) | 48x320 |
+| `eslav_rec` | Cyrillic / East-Slavic recognition (SVTR/CTC) | 48x320 |
+| `thai_rec` | Thai recognition (SVTR/CTC) | 48x320 |
+| `greek_rec` | Greek recognition (SVTR/CTC) | 48x320 |
+
+All seven recognizers share the PP-OCRv5 SVTR/CTC architecture; each ships with
+its own character dictionary baked into the exported weights.
+
+## Setup
+### 1. Install the package
+Install the package via pip:
+```bash
+# NOTE: 3.10 <= PYTHON_VERSION < 3.14 is supported.
+pip install "qai-hub-models[pp-ocrv5]"
+```
+
+### 2. Configure Qualcomm® AI Hub Workbench
+Sign-in to [Qualcomm® AI Hub Workbench](https://workbench.aihub.qualcomm.com/) with your
+Qualcomm® ID. Once signed in navigate to `Account -> Settings -> API Token`.
+
+With this API token, you can configure your client to run models on the cloud
+hosted devices.
+```bash
+qai-hub configure --api_token API_TOKEN
+```
+Navigate to [docs](https://workbench.aihub.qualcomm.com/docs/) for more information.
+
+## Run CLI Demo
+Run the following simple CLI demo to verify the model is working end to end:
+
+```bash
+python -m qai_hub_models.models.pp_ocrv5.demo
+```
+More details on the CLI tool can be found with the `--help` option. See
+[demo.py](demo.py) for sample usage of the model including pre/post processing
+scripts. Please refer to our [general instructions on using
+models](../../../#getting-started) for more usage instructions.
+
+## Export for on-device deployment
+To run the model on Qualcomm® devices, you must export the model for use with an edge runtime such as
+TensorFlow Lite, ONNX Runtime, or Qualcomm AI Engine Direct. Use the following command to export the model:
+```bash
+python -m qai_hub_models.models.pp_ocrv5.export
+```
+Additional options are documented with the `--help` option.
+
+## Performance
+
+Measured on a Samsung Galaxy S25 Ultra (Snapdragon 8 Elite) via Qualcomm AI Hub,
+float TensorFlow Lite, all layers on the Hexagon NPU (no CPU fallback):
+
+| Component | On-device latency |
+|-----------|-------------------|
+| `det` | 1.54 ms |
+| `ko_rec` | 4.39 ms |
+| `zh_rec` | 10.84 ms |
+
+int8 (w8a8) quantization with a calibration set further reduces detection/recognition
+latency to roughly 1.2 / 1.0 / 0.5 ms (measured via post-training quantization).
+
+## Accuracy
+
+Measured on **ReCTS** — real Chinese store-front / signage photographs (curved text,
+occlusion, background clutter), the ReCTS subset of
+[`SWHL/ChineseOCRBench`](https://huggingface.co/datasets/SWHL/ChineseOCRBench) (Apache-2.0),
+n = 200 images, detector + Simplified Chinese recognizer:
+
+| Metric | PP-OCRv5 (det + zh_rec) |
+|--------|-------------------------|
+| Full-string recall | 48.5% |
+| Mean per-character recall | 66.04% |
+
+## License
+* The license for the original implementation of PP-OCRv5 can be found
+  [here](https://github.com/PaddlePaddle/PaddleOCR/blob/main/LICENSE).
+
+## References
+* [PaddleOCR 3.0 Technical Report](https://arxiv.org/abs/2507.05595)
+* [Source Model Implementation](https://github.com/PaddlePaddle/PaddleOCR)
+
+## Community
+* Join [our AI Hub Slack community](https://aihub.qualcomm.com/community/slack) to collaborate, post questions and learn more about on-device AI.
+* For questions or feedback please [reach out to us](mailto:ai-hub-support@qti.qualcomm.com).

--- a/src/qai_hub_models/models/pp_ocrv5/__init__.py
+++ b/src/qai_hub_models/models/pp_ocrv5/__init__.py
@@ -1,0 +1,10 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+
+from .app import PPOCRv5App as App
+from .model import MODEL_ID
+from .model import PPOCRv5 as Model
+
+__all__ = ["MODEL_ID", "App", "Model"]

--- a/src/qai_hub_models/models/pp_ocrv5/app.py
+++ b/src/qai_hub_models/models/pp_ocrv5/app.py
@@ -1,0 +1,242 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+from qai_hub_models.utils.image_processing import app_to_net_image_inputs
+
+DETECTION_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+DETECTION_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+
+def ctc_greedy_decode(logits: np.ndarray, charlist: list[str]) -> str:
+    """Greedy CTC decode a single region's logits into a text string.
+
+    Parameters
+    ----------
+    logits
+        CTC logits of shape ``[T, vocab]`` (or ``[1, T, vocab]``) where the
+        last dimension indexes ``charlist``.
+    charlist
+        The character list, using the PaddleOCR layout
+        ``["<blank>"] + dictionary + [" "]`` so index 0 is the CTC blank.
+
+    Returns
+    -------
+    text : str
+        The decoded text: per-timestep argmax, with consecutive duplicate
+        indices collapsed and blank (index 0) dropped, then mapped to chars.
+    """
+    if logits.ndim == 3:
+        logits = logits[0]
+    best = logits.argmax(axis=-1)
+
+    chars: list[str] = []
+    previous = -1
+    for index in best:
+        index = int(index)
+        # Collapse repeats, then drop the CTC blank (index 0).
+        if index not in (previous, 0) and 0 <= index < len(charlist):
+            chars.append(charlist[index])
+        previous = index
+    return "".join(chars)
+
+
+class PPOCRv5App:
+    """
+    Light-weight "app code" for end-to-end inference with PP-OCRv5.
+
+    The app uses two models:
+        * detector   : produces a per-pixel text probability map
+        * recognizer : reads a text-line crop and produces CTC logits
+
+    For a given image, the app will:
+        * pre-process the image (resize, ImageNet normalize) for detection
+        * run the detector and threshold the probability map into text regions
+        * pre-process each detected region for recognition
+        * run the recognizer to produce CTC logits per region
+        * greedy-CTC-decode the logits into recognized text strings
+    """
+
+    def __init__(
+        self,
+        detector: Callable[[torch.Tensor], torch.Tensor],
+        recognizer: Callable[[torch.Tensor], torch.Tensor],
+        detector_img_shape: tuple[int, int],
+        recognizer_img_shape: tuple[int, int],
+        charlist: list[str] | None = None,
+    ) -> None:
+        self.detector = detector
+        self.recognizer = recognizer
+        self.detector_img_shape = detector_img_shape
+        self.recognizer_img_shape = recognizer_img_shape
+        self.charlist = charlist
+        # (scale, new_w, new_h) of the most recent detector letterbox, used to
+        # map detected boxes from padded detector space back to the frame.
+        self._last_letterbox: tuple[float, int, int] | None = None
+
+    def detector_preprocess(self, frame: np.ndarray) -> torch.Tensor:
+        """Resize and ImageNet-normalize an RGB uint8 image for detection.
+
+        The image is resized while preserving its aspect ratio and then padded
+        ("letterboxed") to the fixed detector input shape. Squishing a wide
+        signboard into a square would distort glyphs and degrade the DB text
+        map, so the letterbox geometry is stored for mapping detected boxes
+        back to the original frame.
+        """
+        import cv2
+
+        height, width = self.detector_img_shape
+        frame_h, frame_w = frame.shape[:2]
+        scale = min(width / frame_w, height / frame_h)
+        new_w = max(1, round(frame_w * scale))
+        new_h = max(1, round(frame_h * scale))
+        resized = cv2.resize(frame, (new_w, new_h))
+
+        canvas = np.zeros((height, width, 3), dtype=np.uint8)
+        canvas[:new_h, :new_w] = resized
+        self._last_letterbox = (scale, new_w, new_h)
+
+        normalized = canvas.astype(np.float32) / 255.0
+        normalized = (normalized - DETECTION_MEAN) / DETECTION_STD
+        chw = normalized.transpose(2, 0, 1)[np.newaxis]
+        return torch.from_numpy(np.ascontiguousarray(chw))
+
+    def recognizer_preprocess(self, crop: np.ndarray) -> torch.Tensor:
+        """Resize a text-line crop (RGB uint8) to the recognizer input shape."""
+        import cv2
+
+        height, width = self.recognizer_img_shape
+        resized = cv2.resize(crop, (width, height)).astype(np.float32) / 255.0
+        chw = resized.transpose(2, 0, 1)[np.newaxis]
+        return torch.from_numpy(np.ascontiguousarray(chw))
+
+    def predict(self, *args: Any, **kwargs: Any) -> list[str]:
+        return self.predict_text_from_image(*args, **kwargs)
+
+    def predict_text_from_image(
+        self,
+        pixel_values_or_image: np.ndarray | Image.Image,
+        charlist: list[str] | None = None,
+    ) -> list[str]:
+        """
+        Detect text regions in an image and recognize the text in each region.
+
+        Parameters
+        ----------
+        pixel_values_or_image
+            PIL image(s), or a numpy array (N H W C or H W C, uint8, RGB).
+        charlist
+            Optional character list for CTC decoding. Defaults to the list
+            supplied at construction time. Must use the PaddleOCR layout
+            ``["<blank>"] + dictionary + [" "]``.
+
+        Returns
+        -------
+        results : list[str]
+            One recognized text string per detected text region, across all
+            input images, ordered top-to-bottom then left-to-right.
+        """
+        charlist = charlist if charlist is not None else self.charlist
+        if charlist is None:
+            raise ValueError(
+                "A character list is required to decode recognition logits. "
+                "Pass `charlist=...` or construct the app with one "
+                "(e.g. recognizer.get_charlist())."
+            )
+
+        nhwc_frames, _ = app_to_net_image_inputs(pixel_values_or_image)
+
+        results: list[str] = []
+        for frame in nhwc_frames:
+            det_input = self.detector_preprocess(frame)
+            prob_map = np.asarray(self.detector(det_input))
+
+            for crop in self._extract_text_crops(frame, prob_map):
+                rec_input = self.recognizer_preprocess(crop)
+                logits = np.asarray(self.recognizer(rec_input))
+                results.append(ctc_greedy_decode(logits, charlist))
+
+        return results
+
+    def _extract_text_crops(
+        self,
+        frame: np.ndarray,
+        prob_map: np.ndarray,
+        threshold: float = 0.3,
+        min_area_frac: float = 1e-4,
+    ) -> list[np.ndarray]:
+        """Threshold the probability map and crop axis-aligned text regions.
+
+        The DB-style probability map fires per-character; neighbouring
+        characters are merged into a single text-line box with a horizontal
+        morphological dilation before extracting connected components. Tiny
+        components (noise) are dropped, and each box is padded slightly so the
+        recognizer sees full glyphs. Regions are returned in reading order
+        (top-to-bottom, then left-to-right) so the strings line up with the
+        image.
+        """
+        import cv2
+
+        mask = (prob_map[0, 0] > threshold).astype(np.uint8)
+        if mask.sum() == 0:
+            return []
+
+        mask_h, mask_w = mask.shape
+        # Dilate horizontally to bridge inter-character gaps into text lines.
+        kernel_w = max(3, mask_w // 40)
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (kernel_w, 3))
+        merged = cv2.dilate(mask, kernel, iterations=1)
+
+        height, width = frame.shape[:2]
+        det_h, det_w = self.detector_img_shape
+
+        # Map mask-space -> detector-input space -> original frame, undoing the
+        # aspect-preserving letterbox applied in `detector_preprocess`.
+        if self._last_letterbox is not None:
+            lb_scale, new_w, new_h = self._last_letterbox
+        else:
+            lb_scale, new_w, new_h = (1.0, det_w, det_h)
+        mask_to_det_x = det_w / mask_w
+        mask_to_det_y = det_h / mask_h
+
+        min_area = min_area_frac * mask_h * mask_w
+        pad_x = max(1, int(0.01 * width))
+        pad_y = max(1, int(0.01 * height))
+
+        def to_frame(mx: float, my: float) -> tuple[float, float]:
+            # mask -> detector-input pixels, then -> original frame pixels.
+            dx = min(mx * mask_to_det_x, new_w)
+            dy = min(my * mask_to_det_y, new_h)
+            return dx / lb_scale, dy / lb_scale
+
+        contours, _ = cv2.findContours(
+            merged, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
+        boxes: list[tuple[int, int, int, int]] = []
+        for contour in contours:
+            if cv2.contourArea(contour) < min_area:
+                continue
+            x, y, w, h = cv2.boundingRect(contour)
+            fx0, fy0 = to_frame(x, y)
+            fx1, fy1 = to_frame(x + w, y + h)
+            x0 = max(0, int(fx0) - pad_x)
+            y0 = max(0, int(fy0) - pad_y)
+            x1 = min(width, int(fx1) + pad_x)
+            y1 = min(height, int(fy1) + pad_y)
+            if x1 - x0 <= 0 or y1 - y0 <= 0:
+                continue
+            boxes.append((x0, y0, x1, y1))
+
+        # Reading order: group by approximate text-line (top), then by x.
+        boxes.sort(key=lambda b: (b[1], b[0]))
+        return [frame[y0:y1, x0:x1] for (x0, y0, x1, y1) in boxes]

--- a/src/qai_hub_models/models/pp_ocrv5/code-gen.yaml
+++ b/src/qai_hub_models/models/pp_ocrv5/code-gen.yaml
@@ -1,0 +1,3 @@
+supported_precisions:
+- float
+is_collection_model: true

--- a/src/qai_hub_models/models/pp_ocrv5/conftest.py
+++ b/src/qai_hub_models/models/pp_ocrv5/conftest.py
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+# THIS FILE WAS AUTO-GENERATED. DO NOT EDIT MANUALLY.
+
+import gc
+import warnings
+
+import pytest
+import torch.jit._trace
+
+from qai_hub_models.models.pp_ocrv5 import Model
+from qai_hub_models.scorecard.utils.testing import make_cached_from_pretrained_fixture
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # pytest is unable to figure out how to silence several PyTorch warning types from pyproject.toml settings,
+    # so we apply a manual warning filter here instead.
+    warnings.filterwarnings(action="ignore", category=torch.jit._trace.TracerWarning)
+    warnings.filterwarnings(action="ignore", category=UserWarning, module="torch.*")
+    warnings.filterwarnings(action="ignore", category=FutureWarning, module="torch.*")
+    warnings.filterwarnings(
+        action="ignore", category=DeprecationWarning, module="torch.*"
+    )
+
+
+# Instantiate the model only once for all tests.
+# Mock from_pretrained to always return the initialized model.
+# This speeds up tests and limits memory leaks.
+cached_from_pretrained = make_cached_from_pretrained_fixture(
+    Model, skip_clone_repo=True
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_gc() -> None:
+    gc.collect()

--- a/src/qai_hub_models/models/pp_ocrv5/demo.py
+++ b/src/qai_hub_models/models/pp_ocrv5/demo.py
@@ -1,0 +1,65 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+
+from qai_hub_models.models.pp_ocrv5.app import PPOCRv5App
+from qai_hub_models.models.pp_ocrv5.model import (
+    MODEL_ASSET_VERSION,
+    MODEL_ID,
+    PPOCRv5,
+)
+from qai_hub_models.utils.args import get_model_cli_parser, model_from_cli_args
+from qai_hub_models.utils.asset_loaders import CachedWebModelAsset, load_image
+
+INPUT_IMAGE_ADDRESS = CachedWebModelAsset.from_asset_store(
+    MODEL_ID, MODEL_ASSET_VERSION, "signage.jpg"
+)
+
+
+def main(is_test: bool = False) -> None:
+    # Demo parameters
+    parser = get_model_cli_parser(PPOCRv5)
+    parser.add_argument(
+        "--image",
+        type=str,
+        default=INPUT_IMAGE_ADDRESS,
+        help="image file path or URL",
+    )
+    parser.add_argument(
+        "--lang",
+        type=str,
+        default="zh",
+        choices=["zh", "ko", "en", "latin", "eslav", "thai", "greek"],
+        help="recognition language component to use",
+    )
+    args = parser.parse_args([] if is_test else None)
+
+    # Load model and image
+    model = model_from_cli_args(PPOCRv5, args)
+    image = load_image(args.image)
+
+    recognizer = getattr(model, f"{args.lang}_rec")
+    app = PPOCRv5App(
+        model.det,
+        recognizer,
+        tuple(model.det.get_input_spec()["image"][0][2:4]),
+        tuple(recognizer.get_input_spec()["image"][0][2:4]),
+        charlist=recognizer.get_charlist(),
+    )
+    print("Model Loaded")
+
+    # `results` holds the recognized text (one string per detected region),
+    # produced by greedy CTC decoding the recognizer logits.
+    results = app.predict_text_from_image(image)
+
+    if not is_test:
+        print(f"Detected {len(results)} text region(s).")
+        for i, text in enumerate(results):
+            print(f"region {i}: {text}")
+        print("\nRecognized text:")
+        print("\n".join(text for text in results if text))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qai_hub_models/models/pp_ocrv5/export.py
+++ b/src/qai_hub_models/models/pp_ocrv5/export.py
@@ -1,0 +1,648 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+# THIS FILE WAS AUTO-GENERATED. DO NOT EDIT MANUALLY.
+
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any
+
+import qai_hub as hub
+
+from qai_hub_models import Precision, TargetRuntime
+from qai_hub_models.common import SampleInputsType
+from qai_hub_models.configs.model_metadata import (
+    ChipsetAttributes,
+    ModelFileMetadata,
+    ModelMetadata,
+    merge_input_metadata,
+    merge_output_metadata,
+)
+from qai_hub_models.configs.tool_versions import ToolVersions
+from qai_hub_models.models.pp_ocrv5 import MODEL_ID, App, Model
+from qai_hub_models.utils import quantization as quantization_utils
+from qai_hub_models.utils.args import (
+    export_parser,
+    get_component_input_spec_kwargs,
+    get_export_model_name,
+    get_model_kwargs,
+)
+from qai_hub_models.utils.asset_loaders import ASSET_CONFIG
+from qai_hub_models.utils.base_model import PretrainedCollectionModel
+from qai_hub_models.utils.compare import torch_inference
+from qai_hub_models.utils.export_result import CollectionExportResult, ComponentGroup
+from qai_hub_models.utils.export_without_hub_access import export_without_hub_access
+from qai_hub_models.utils.input_spec import InputSpec, to_hub_input_specs
+from qai_hub_models.utils.onnx.helpers import download_and_unzip_workbench_onnx_model
+from qai_hub_models.utils.path_helpers import get_next_free_path
+from qai_hub_models.utils.printing import (
+    print_inference_metrics,
+    print_profile_metrics_from_job,
+    print_tool_versions,
+)
+from qai_hub_models.utils.qai_hub_helpers import (
+    assert_success_and_get_target_models,
+    can_access_qualcomm_ai_hub,
+)
+
+
+def quantize_model(
+    precision: Precision | dict[str, Precision],
+    model: PretrainedCollectionModel,
+    model_name: str,
+    onnx_models: ComponentGroup[hub.Model],
+    num_calibration_samples: int | None,
+    extra_options: str = "",
+    input_specs: dict[str, InputSpec] | None = None,
+    components: list[str] | None = None,
+) -> ComponentGroup[hub.client.QuantizeJob]:
+    component_precisions = (
+        model.get_mixed_precisions(precision)
+        if isinstance(precision, Precision)
+        else precision
+    )
+    quantize_jobs: ComponentGroup[hub.client.QuantizeJob] = ComponentGroup()
+    input_specs = input_specs or model.get_input_spec()
+    for component_name in components or Model.component_class_names:
+        component_precision = component_precisions[component_name]
+
+        if component_precision != Precision.float:
+            print(f"Quantizing {component_name}.")
+            if (
+                not component_precision.activations_type
+                or not component_precision.weights_type
+            ):
+                raise ValueError(
+                    "Quantization is only supported if both weights and activations are quantized."
+                )
+
+            calibration_data = quantization_utils.get_calibration_data(
+                model,
+                input_specs,
+                num_calibration_samples,
+                component_name=component_name,
+                app=App,
+            )
+            quantize_jobs[component_name] = hub.submit_quantize_job(
+                model=onnx_models[component_name],
+                calibration_data=calibration_data,
+                activations_dtype=component_precision.activations_type,
+                weights_dtype=component_precision.weights_type,
+                name=f"{model_name}_{component_name}",
+                options=model.get_component_hub_quantize_options(
+                    component_name, component_precision, extra_options
+                ),
+            )
+    return quantize_jobs
+
+
+def upload_model(
+    model: PretrainedCollectionModel,
+    input_specs: dict[str, InputSpec] | None = None,
+    components: list[str] | None = None,
+) -> ComponentGroup[hub.Model]:
+    all_input_specs = input_specs or model.get_input_spec()
+    uploaded: ComponentGroup[hub.Model] = ComponentGroup()
+    for name in components or Model.component_class_names:
+        spec = all_input_specs[name]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uploaded[name] = hub.upload_model(
+                str(model.serialize_component(name, tmpdir, spec))
+            )
+    return uploaded
+
+
+def compile_model(
+    model: PretrainedCollectionModel,
+    model_name: str,
+    device: hub.Device,
+    target_runtime: TargetRuntime,
+    precision: Precision,
+    source_models: ComponentGroup[hub.Model],
+    input_specs: dict[str, InputSpec] | None = None,
+    components: list[str] | None = None,
+    extra_options: str = "",
+) -> ComponentGroup[hub.client.CompileJob]:
+    compile_jobs: ComponentGroup[hub.client.CompileJob] = ComponentGroup()
+    all_input_specs = input_specs or model.get_input_spec()
+    for component_name in components or Model.component_class_names:
+        input_spec = all_input_specs[component_name]
+
+        model_compile_options = model.get_component_hub_compile_options(
+            component_name, target_runtime, precision, extra_options, device
+        )
+        print(f"Optimizing model {component_name} to run on-device")
+        compile_jobs[component_name] = hub.submit_compile_job(
+            model=source_models[component_name],
+            input_specs=to_hub_input_specs(input_spec),
+            device=device,
+            name=f"{model_name}_{component_name}",
+            options=model_compile_options,
+        )
+    return compile_jobs
+
+
+def link_model(
+    compiled_models: ComponentGroup[hub.Model],
+    device: hub.Device,
+    model_name: str,
+    model: PretrainedCollectionModel,
+    target_runtime: TargetRuntime,
+    extra_options: str = "",
+) -> ComponentGroup[hub.client.LinkJob]:
+    """Link compiled DLCs to context binary for AOT."""
+    assert target_runtime.is_aot_compiled, (
+        f"link_model() requires an AOT runtime, got {target_runtime}"
+    )
+    link_jobs: ComponentGroup[hub.client.LinkJob] = ComponentGroup()
+    for component_name, compiled_model in compiled_models.items():
+        link_options = model.get_component_hub_link_options(
+            component_name, target_runtime, extra_options
+        )
+        print(f"Linking {component_name} to context binary")
+        link_jobs[component_name] = hub.submit_link_job(
+            [compiled_model],
+            device=device,
+            name=f"{model_name}_{component_name}",
+            options=link_options,
+        )
+    return link_jobs
+
+
+def profile_model(
+    model_name: str,
+    device: hub.Device,
+    options: ComponentGroup[str],
+    target_models: ComponentGroup[hub.Model],
+    components: list[str] | None = None,
+) -> ComponentGroup[hub.client.ProfileJob]:
+    profile_jobs: ComponentGroup[hub.client.ProfileJob] = ComponentGroup()
+    for component_name in components or Model.component_class_names:
+        print(f"Profiling model {component_name} on a hosted device.")
+        profile_jobs[component_name] = hub.submit_profile_job(
+            model=target_models[component_name],
+            device=device,
+            name=f"{model_name}_{component_name}",
+            options=options.get(component_name, ""),
+        )
+    return profile_jobs
+
+
+def inference_model(
+    inputs: ComponentGroup[SampleInputsType],
+    model_name: str,
+    device: hub.Device,
+    options: ComponentGroup[str],
+    target_models: ComponentGroup[hub.Model],
+    components: list[str] | None = None,
+) -> ComponentGroup[hub.client.InferenceJob]:
+    inference_jobs: ComponentGroup[hub.client.InferenceJob] = ComponentGroup()
+    for component_name in components or Model.component_class_names:
+        print(
+            f"Running inference for {component_name} on a hosted device with example inputs."
+        )
+        inference_jobs[component_name] = hub.submit_inference_job(
+            model=target_models[component_name],
+            inputs=inputs[component_name],
+            device=device,
+            name=f"{model_name}_{component_name}",
+            options=options.get(component_name, ""),
+        )
+    return inference_jobs
+
+
+def download_model(
+    output_dir: os.PathLike | str,
+    model: PretrainedCollectionModel,
+    runtime: TargetRuntime,
+    precision: Precision,
+    tool_versions: ToolVersions,
+    target_models: ComponentGroup[hub.Model],
+    zip_assets: bool,
+    hub_device: hub.Device | None = None,
+) -> Path:
+    output_folder_name = os.path.basename(output_dir)
+    output_path = get_next_free_path(output_dir)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dst_path = Path(tmpdir) / output_folder_name
+        dst_path.mkdir()
+
+        # Download models and capture filenames, then generate metadata
+        model_file_metadata = {}
+        for component_name, target_model in target_models.items():
+            if target_model.model_type == hub.SourceModelType.ONNX:
+                onnx_result = download_and_unzip_workbench_onnx_model(
+                    target_model, dst_path, component_name
+                )
+                model_file_name = onnx_result.onnx_graph_name
+            else:
+                downloaded_path = target_model.download(
+                    os.path.join(dst_path, component_name)
+                )
+                model_file_name = os.path.basename(downloaded_path)
+
+            # Generate metadata using the actual downloaded filename
+            model_file_metadata[model_file_name] = ModelFileMetadata.from_hub_model(
+                target_model
+            )
+            # Merge semantic metadata from get_input_spec()
+            merge_input_metadata(
+                model_file_metadata[model_file_name],
+                model.get_component_input_spec(component_name),
+            )
+            merge_output_metadata(
+                model_file_metadata[model_file_name],
+                model.get_component_output_spec(component_name),
+            )
+
+        # Extract and save metadata alongside downloaded model
+        metadata_path = dst_path / "metadata.json"
+        model_metadata = ModelMetadata(
+            model_id=MODEL_ID,
+            model_name="PP-OCRv5",
+            runtime=runtime,
+            precision=precision,
+            tool_versions=tool_versions,
+            model_files=model_file_metadata,
+            chipset_attributes=ChipsetAttributes.from_hub_device(hub_device)
+            if runtime.is_aot_compiled
+            else None,
+        )
+
+        # Dump supplementary files into the model folder
+        model.write_supplementary_files(dst_path, model_metadata)
+
+        model_metadata.to_json(metadata_path)
+        if zip_assets:
+            output_path = Path(
+                shutil.make_archive(
+                    str(output_path),
+                    "zip",
+                    root_dir=tmpdir,
+                    base_dir=output_folder_name,
+                )
+            )
+        else:
+            shutil.move(dst_path, output_path)
+
+    return output_path
+
+
+def export_model(
+    device: hub.Device,
+    components: list[str] | None = None,
+    precision: Precision = Precision.float,
+    num_calibration_samples: int | None = None,
+    quantized_model_id: dict[str, str] | None = None,
+    skip_compiling: bool = False,
+    skip_profiling: bool = False,
+    skip_inferencing: bool = False,
+    skip_downloading: bool = False,
+    skip_summary: bool = False,
+    output_dir: str | None = None,
+    target_runtime: TargetRuntime = TargetRuntime.TFLITE,
+    compile_options: str = "",
+    quantize_options: str = "",
+    profile_options: str = "",
+    fetch_static_assets: str | None = None,
+    zip_assets: bool = False,
+    **additional_model_kwargs: Any,
+) -> CollectionExportResult:
+    """
+    This function executes the following recipe:
+
+        1. Instantiates a PyTorch model and converts it to a traced TorchScript format
+        2. Converts the PyTorch model to ONNX and quantizes the ONNX model.
+        3. Compiles the model to an asset that can be run on device
+        4. Profiles the model performance on a real device
+        5. Inferences the model on sample inputs
+        6. Extracts relevant tool (eg. SDK) versions used to compile and profile this model
+        7. Downloads the model asset to the local directory
+        8. Summarizes the results from profiling and inference
+
+    Each of the last 6 steps can be optionally skipped using the input options.
+
+    Parameters
+    ----------
+    device
+        Device for which to export the model (e.g., hub.Device("Samsung Galaxy S25")).
+        Full list of available devices can be found by running `hub.get_devices()`.
+    components
+        List of sub-components of the model that will be exported.
+        Each component is compiled and profiled separately.
+        Defaults to all components of the CollectionModel if not specified.
+    precision
+        The precision to which this model should be quantized.
+        Quantization is skipped if the precision is float.
+    num_calibration_samples
+        The number of calibration data samples
+        to use for quantization. If not set, uses the default number
+        specified by the dataset. If model doesn't have a calibration dataset
+        specified, this must be None.
+    quantized_model_id
+        A quantized ONNX hub model id, skips quantizing model.
+    skip_compiling
+        If set, skips compiling of model to format that can run on device.
+    skip_profiling
+        If set, skips profiling of compiled model on real devices.
+    skip_inferencing
+        If set, skips computing on-device outputs from sample data.
+    skip_downloading
+        If set, skips downloading of compiled model.
+    skip_summary
+        If set, skips waiting for and summarizing results
+        from profiling and inference.
+    output_dir
+        Directory to store generated assets (e.g. compiled model).
+        Defaults to `<cwd>/export_assets`.
+    target_runtime
+        Which on-device runtime to target. Default is TFLite.
+    compile_options
+        Additional options to pass when submitting the compile job.
+    quantize_options
+        Additional options to pass when submitting the quantize job.
+    profile_options
+        Additional options to pass when submitting the profile job.
+    fetch_static_assets
+        If set, known assets are fetched from the given version rather than re-computing them. Can be passed as "latest" or "v<version>".
+    zip_assets
+        If set, zip the assets after downloading.
+    **additional_model_kwargs
+        Additional optional kwargs used to customize
+        `model_cls.from_pretrained` and per-component `get_input_spec`
+
+    Returns
+    -------
+    CollectionExportResult
+            * A CompileJob object containing metadata about the compile job submitted to hub (None if compiling skipped).
+            * An InferenceJob containing metadata about the inference job (None if inferencing skipped).
+            * A ProfileJob containing metadata about the profile job (None if profiling skipped).
+            * A QuantizeJob object containing metadata about the quantize job submitted to hub
+        * The path to the downloaded model folder (or zip), or None if one or more of: skip_downloading is True, fetch_static_assets is set, or AI Hub Workbench is not accessible
+    """
+    model_name = get_export_model_name(
+        Model, MODEL_ID, precision, additional_model_kwargs
+    )
+
+    output_path = Path(output_dir or Path.cwd() / "export_assets")
+    component_arg = components
+    components = components or Model.component_class_names
+    for component_name in components:
+        if component_name not in Model.component_class_names:
+            raise ValueError(f"Invalid component {component_name}.")
+    if fetch_static_assets or not can_access_qualcomm_ai_hub():
+        static_model_path = export_without_hub_access(
+            MODEL_ID,
+            device,
+            skip_profiling,
+            skip_inferencing,
+            skip_downloading,
+            skip_summary,
+            output_path,
+            target_runtime,
+            precision,
+            quantize_options + compile_options + profile_options,
+            component_arg,
+            qaihm_version_tag=fetch_static_assets,
+        )
+        return CollectionExportResult(download_path=static_model_path)
+
+    hub_device = hub.get_devices(
+        name=device.name, attributes=device.attributes, os=device.os
+    )[-1]
+    chipset_attr = next(
+        (attr for attr in hub_device.attributes if "chipset" in attr), None
+    )
+    chipset = chipset_attr.split(":")[-1] if chipset_attr else None
+
+    # 1. Instantiates a PyTorch model and converts it to a traced TorchScript format
+    model = Model.from_pretrained(
+        **get_model_kwargs(Model, dict(**additional_model_kwargs, precision=precision))
+    )
+    input_specs: ComponentGroup[InputSpec] = ComponentGroup(
+        {
+            name: model.components[name].get_input_spec(
+                **get_component_input_spec_kwargs(Model, name, additional_model_kwargs)
+            )
+            for name in components
+        }
+    )
+    source_models_to_compile = upload_model(model, input_specs, components)
+
+    # 2. Converts the PyTorch model to ONNX and quantizes the ONNX model.
+    quantize_jobs: ComponentGroup[hub.client.QuantizeJob] | None = None
+    quantized_models: ComponentGroup[hub.Model] | None = None
+    if precision != Precision.float:
+        if quantized_model_id:
+            quantized_models = ComponentGroup(
+                {
+                    component: hub_model
+                    for component in components
+                    if (hub_model := hub.get_model(quantized_model_id[component]))
+                    is not None
+                }
+            )
+        else:
+            component_precisions = model.get_mixed_precisions(precision)
+            onnx_compile_result = compile_model(
+                model,
+                model_name,
+                device,
+                TargetRuntime.ONNX,
+                precision,
+                source_models_to_compile,
+                input_specs=input_specs,
+                components=[
+                    c
+                    for c, p in component_precisions.items()
+                    if c in components and p != Precision.float
+                ],
+            )
+            onnx_models = assert_success_and_get_target_models(onnx_compile_result)
+            quantize_jobs = quantize_model(
+                component_precisions,
+                model,
+                model_name,
+                onnx_models,
+                num_calibration_samples,
+                quantize_options,
+                input_specs,
+                components,
+            )
+            if skip_compiling:
+                return CollectionExportResult(quantize_jobs=quantize_jobs)
+            quantized_models = assert_success_and_get_target_models(quantize_jobs)
+
+    # 3. Compiles the model to an asset that can be run on device
+    if quantized_models:
+        source_models_to_compile |= quantized_models
+    compile_result = compile_model(
+        model,
+        model_name,
+        device,
+        target_runtime,
+        precision,
+        source_models_to_compile,
+        input_specs=input_specs,
+        components=components,
+        extra_options=compile_options,
+    )
+
+    link_result: ComponentGroup[hub.client.LinkJob] | None = None
+    target_models: ComponentGroup[hub.Model]
+    if target_runtime.uses_hub_link:
+        compiled_models = assert_success_and_get_target_models(compile_result)
+        link_result = link_model(
+            compiled_models,
+            device,
+            model_name,
+            model,
+            target_runtime,
+        )
+    target_models = assert_success_and_get_target_models(link_result or compile_result)
+
+    # 4. Profiles the model performance on a real device
+    profile_result: ComponentGroup[hub.client.ProfileJob] | None = None
+    if not skip_profiling:
+        profile_result = profile_model(
+            model_name,
+            device,
+            model.get_hub_profile_options(target_runtime, profile_options),
+            target_models,
+            components,
+        )
+
+    # 5. Inferences the model on sample inputs
+    inference_result: ComponentGroup[hub.client.InferenceJob] | None = None
+    if not skip_inferencing:
+        inference_result = inference_model(
+            model.sample_inputs(
+                input_specs=input_specs,
+                use_channel_last_format=target_runtime.channel_last_native_execution,
+            ),
+            model_name,
+            device,
+            model.get_hub_profile_options(target_runtime, profile_options),
+            target_models,
+            components,
+        )
+
+    # 6. Extracts relevant tool (eg. SDK) versions used to compile and profile this model
+    tool_versions: ToolVersions | None = None
+    tool_versions_are_from_device_job = False
+    if not skip_summary or not skip_downloading:
+        profile_job = (
+            next(iter(profile_result.values()), None) if profile_result else None
+        )
+        inference_job = (
+            next(iter(inference_result.values()), None) if inference_result else None
+        )
+        compile_job = next(iter(compile_result.values()), None)
+        if profile_job is not None and profile_job.wait():
+            tool_versions = ToolVersions.from_job(profile_job)
+            tool_versions_are_from_device_job = True
+        elif inference_job is not None and inference_job.wait():
+            tool_versions = ToolVersions.from_job(inference_job)
+            tool_versions_are_from_device_job = True
+        elif compile_job and compile_job.wait():
+            tool_versions = ToolVersions.from_job(compile_job)
+
+    # 7. Downloads the model asset to the local directory
+    downloaded_model_path: Path | None = None
+    if not skip_downloading and tool_versions is not None:
+        model_directory = output_path / ASSET_CONFIG.get_release_asset_name(
+            MODEL_ID, target_runtime, precision, chipset
+        )
+        downloaded_model_path = download_model(
+            model_directory,
+            model,
+            target_runtime,
+            precision,
+            tool_versions,
+            target_models,
+            zip_assets,
+            hub_device=hub_device,
+        )
+
+    # 8. Summarizes the results from profiling and inference
+    if not skip_summary and profile_result is not None:
+        for profile_job in profile_result.values():
+            assert profile_job.wait().success, "Job failed: " + profile_job.url
+            profile_data: dict[str, Any] = profile_job.download_profile()
+            print_profile_metrics_from_job(profile_job, profile_data)
+
+    if not skip_summary and inference_result is not None:
+        for component_name in components:
+            component = model.components[component_name]
+            inference_job = inference_result[component_name]
+            sample_inputs = component.sample_inputs(
+                input_specs[component_name], use_channel_last_format=False
+            )
+            torch_out = torch_inference(
+                component,
+                sample_inputs,
+                return_channel_last_output=target_runtime.channel_last_native_execution,
+            )
+            assert inference_job.wait().success, "Job failed: " + inference_job.url
+            ij_output = inference_job.download_output_data()
+            assert ij_output is not None
+            print_inference_metrics(
+                inference_job, ij_output, torch_out, component.get_output_names()
+            )
+
+    if not skip_summary:
+        print_tool_versions(tool_versions, tool_versions_are_from_device_job)
+
+    if downloaded_model_path:
+        print(f"{model_name} was saved to {downloaded_model_path}\n")
+
+    return CollectionExportResult(
+        quantize_jobs=quantize_jobs if precision != Precision.float else None,
+        compile_jobs=compile_result,
+        link_jobs=link_result,
+        profile_jobs=profile_result,
+        inference_jobs=inference_result,
+        download_path=downloaded_model_path,
+        tool_versions=tool_versions,
+    )
+
+
+def main() -> None:
+    warnings.filterwarnings("ignore")
+    supported_precision_runtimes: dict[Precision, list[TargetRuntime]] = {
+        Precision.float: [
+            TargetRuntime.TFLITE,
+            TargetRuntime.QNN_DLC,
+            TargetRuntime.QNN_CONTEXT_BINARY,
+            TargetRuntime.ONNX,
+            TargetRuntime.PRECOMPILED_QNN_ONNX,
+        ],
+        Precision.w8a8: [
+            TargetRuntime.TFLITE,
+            TargetRuntime.QNN_DLC,
+            TargetRuntime.QNN_CONTEXT_BINARY,
+            TargetRuntime.ONNX,
+            TargetRuntime.PRECOMPILED_QNN_ONNX,
+        ],
+    }
+
+    parser = export_parser(
+        model_cls=Model,
+        export_fn=export_model,
+        supported_precision_runtimes=supported_precision_runtimes,
+        default_export_device="Samsung Galaxy S25 (Family)",
+    )
+    args = parser.parse_args()
+    export_model(**vars(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qai_hub_models/models/pp_ocrv5/info.yaml
+++ b/src/qai_hub_models/models/pp_ocrv5/info.yaml
@@ -1,0 +1,34 @@
+name: PP-OCRv5
+id: pp_ocrv5
+status: pending
+headline: PaddleOCR v5 text detection with recognition for 7 languages for on-device OCR.
+domain: Multimodal
+description: PP-OCRv5 is a multilingual OCR pipeline with a shared text detector and language-specific recognizers. This collection bundles the detector with all seven PP-OCRv5 recognition components — Simplified Chinese (with Japanese coverage), English, Latin-script, Cyrillic / East-Slavic, Korean, Thai, and Greek — for fully on-device optical character recognition.
+use_case: Image To Text
+tags: []
+applicable_scenarios:
+- Signage Translation
+- Document Management
+- Offline OCR
+related_models:
+- easyocr
+- trocr
+form_factors:
+- Phone
+- Tablet
+has_static_banner: false
+has_animated_banner: false
+dataset: []
+technical_details:
+  Source model: PP-OCRv5 (PaddleOCR 3.x, ONNX export from monkt/paddleocr-onnx on Hugging Face)
+  Detection model: PP-OCRv5 mobile detection (PP-HGNetV2 + DB++)
+  Detection input resolution: 640x640
+  Recognition models: PP-OCRv5 SVTR/CTC recognizers for 7 languages (zh_rec Simplified Chinese with Japanese coverage, en_rec English, latin_rec Latin-script, eslav_rec Cyrillic/East-Slavic, ko_rec Korean, thai_rec Thai, greek_rec Greek)
+  Recognition input resolution: 48x320
+  NPU latency (Samsung Galaxy S25 Ultra, float TFLite, 100% NPU): det 1.54 ms, ko_rec 4.39 ms, zh_rec 10.84 ms
+  Accuracy (ReCTS real signage, n=200, det + zh_rec): 48.5% full-string recall, 66.04% mean per-character recall
+license_type: apache-2.0
+research_paper: https://arxiv.org/abs/2507.05595
+research_paper_title: PaddleOCR 3.0 Technical Report
+source_repo: https://github.com/PaddlePaddle/PaddleOCR
+license: https://github.com/PaddlePaddle/PaddleOCR/blob/main/LICENSE

--- a/src/qai_hub_models/models/pp_ocrv5/model.py
+++ b/src/qai_hub_models/models/pp_ocrv5/model.py
@@ -1,0 +1,335 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import onnxruntime
+import torch
+from typing_extensions import Self
+
+from qai_hub_models.utils.asset_loaders import CachedWebModelAsset
+from qai_hub_models.utils.base_model import (
+    BaseModel,
+    CollectionModel,
+    PretrainedCollectionModel,
+)
+from qai_hub_models.utils.input_spec import (
+    ColorFormat,
+    ImageMetadata,
+    InputSpec,
+    IoType,
+    TensorSpec,
+)
+from qai_hub_models.utils.onnx.torch_wrapper import OnnxSessionTorchWrapper
+
+MODEL_ID = __name__.split(".")[-2]
+MODEL_ASSET_VERSION = 1
+
+# Apache-2.0 ONNX exports of the PaddleOCR v5 pipeline (no pickle, no opaque
+# binary model formats). Mirrored on Hugging Face.
+SOURCE_REPO = "https://huggingface.co/monkt/paddleocr-onnx"
+DET_ONNX_URL = f"{SOURCE_REPO}/resolve/main/detection/v3/det.onnx"
+ZH_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/chinese/rec.onnx"
+KO_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/korean/rec.onnx"
+EN_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/english/rec.onnx"
+LATIN_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/latin/rec.onnx"
+ESLAV_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/eslav/rec.onnx"
+THAI_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/thai/rec.onnx"
+GREEK_REC_ONNX_URL = f"{SOURCE_REPO}/resolve/main/languages/greek/rec.onnx"
+
+# Each recognition language ships a character dictionary (one character per
+# UTF-8 line) alongside its ONNX graph. CTC decoding maps logit indices to the
+# characters in this dictionary.
+ZH_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/chinese/dict.txt"
+KO_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/korean/dict.txt"
+EN_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/english/dict.txt"
+LATIN_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/latin/dict.txt"
+ESLAV_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/eslav/dict.txt"
+THAI_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/thai/dict.txt"
+GREEK_DICT_URL = f"{SOURCE_REPO}/resolve/main/languages/greek/dict.txt"
+
+_REC_DICT_URLS = {
+    "zh": ZH_DICT_URL,
+    "ko": KO_DICT_URL,
+    "en": EN_DICT_URL,
+    "latin": LATIN_DICT_URL,
+    "eslav": ESLAV_DICT_URL,
+    "thai": THAI_DICT_URL,
+    "greek": GREEK_DICT_URL,
+}
+
+# Recognition models read fixed-height text crops with a width chosen by the
+# caller. We pin a representative export width that matches our benchmark crops.
+DETECTION_RESOLUTION = (640, 640)
+RECOGNITION_HEIGHT = 48
+RECOGNITION_WIDTH = 320
+
+
+def _fetch_onnx(url: str, filename: str) -> str:
+    """Fetch the source ONNX file to the local asset cache and return its path."""
+    asset = CachedWebModelAsset(url, MODEL_ID, MODEL_ASSET_VERSION, filename)
+    return str(asset.fetch())
+
+
+class _OnnxSourceModel(BaseModel):
+    """Base class for PP-OCRv5 components backed by a source ONNX graph.
+
+    The model source is provided directly as ONNX. ``forward`` runs the graph
+    with ONNX Runtime so the component is usable for local (host) inference,
+    while ``serialize`` hands the original ONNX file to the export pipeline so
+    AI Hub Workbench compiles the real graph instead of tracing a Python module
+    that wraps an inference session.
+    """
+
+    def __init__(self, onnx_path: str) -> None:
+        super().__init__()
+        self.onnx_path = onnx_path
+        self._wrapper = OnnxSessionTorchWrapper(
+            onnxruntime.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+        )
+
+    def forward(self, image: torch.Tensor) -> torch.Tensor:
+        return self._wrapper(image)
+
+    def serialize(
+        self,
+        output_dir: str | os.PathLike,
+        input_spec: InputSpec | None = None,
+    ) -> Path:
+        """Provide the source ONNX directly to the export/compile pipeline."""
+        dst = Path(output_dir) / f"{self.name}.onnx"
+        if dst.resolve() != Path(self.onnx_path).resolve():
+            shutil.copyfile(self.onnx_path, dst)
+        return dst
+
+
+class PPOCRv5Detector(_OnnxSourceModel):
+    """PP-OCRv5 text detection (PP-HGNetV2 backbone + DB++ head)."""
+
+    @classmethod
+    def from_pretrained(cls) -> Self:
+        return cls(_fetch_onnx(DET_ONNX_URL, "det.onnx"))
+
+    def forward(self, image: torch.Tensor) -> torch.Tensor:
+        """
+        Run text detection on `image` and produce a per-pixel text probability map.
+
+        Parameters
+        ----------
+        image
+            Pixel values pre-processed for detector consumption.
+            Range: float[0, 1]
+            3-channel Color Space: RGB
+
+        Returns
+        -------
+        prob_map : torch.Tensor
+            Per-pixel text probability map. Shape [batch, 1, H, W].
+        """
+        return super().forward(image)
+
+    def get_input_spec(
+        self,
+        batch_size: int = 1,
+        height: int = DETECTION_RESOLUTION[0],
+        width: int = DETECTION_RESOLUTION[1],
+    ) -> InputSpec:
+        return {
+            "image": TensorSpec(
+                shape=(batch_size, 3, height, width),
+                dtype="float32",
+                io_type=IoType.IMAGE,
+                value_range=(0.0, 1.0),
+                image_metadata=ImageMetadata(
+                    color_format=ColorFormat.RGB,
+                ),
+            ),
+        }
+
+    def get_output_names(self) -> list[str]:
+        return ["prob_map"]
+
+    def get_channel_last_inputs(self) -> list[str]:
+        return ["image"]
+
+
+class PPOCRv5Recognizer(_OnnxSourceModel):
+    """PP-OCRv5 text recognition (SVTR backbone + CTC head).
+
+    A single recognition architecture serves multiple languages; the only
+    difference between the language variants is the character dictionary that
+    maps CTC logit indices to characters.
+    """
+
+    def __init__(self, onnx_path: str, lang: str | None = None) -> None:
+        super().__init__(onnx_path)
+        self.lang = lang
+        self._charlist: list[str] | None = None
+
+    @classmethod
+    def from_pretrained(cls, lang: str = "zh") -> Self:
+        urls = {
+            "zh": ZH_REC_ONNX_URL,
+            "ko": KO_REC_ONNX_URL,
+            "en": EN_REC_ONNX_URL,
+            "latin": LATIN_REC_ONNX_URL,
+            "eslav": ESLAV_REC_ONNX_URL,
+            "thai": THAI_REC_ONNX_URL,
+            "greek": GREEK_REC_ONNX_URL,
+        }
+        if lang not in urls:
+            raise ValueError(f"Unsupported recognition language: {lang!r}")
+        return cls(_fetch_onnx(urls[lang], f"{lang}_rec.onnx"), lang=lang)
+
+    def get_charlist(self) -> list[str]:
+        """Return the CTC character list for this recognizer.
+
+        PaddleOCR CTC decoding uses the layout
+        ``["<blank>"] + dictionary + [" "]`` so that index 0 is the CTC blank
+        and the final index is the space character. The resulting list length
+        equals the recognizer's logit vocabulary (e.g. 18385 for Chinese).
+
+        The dictionary characters are read from the ``character`` metadata
+        baked into the ONNX graph when present; otherwise they are loaded from
+        the per-language ``dict.txt`` shipped alongside the ONNX weights.
+        """
+        if self._charlist is not None:
+            return self._charlist
+
+        import onnx
+
+        chars: list[str] = []
+        model = onnx.load(self.onnx_path, load_external_data=False)
+        for prop in model.metadata_props:
+            if prop.key == "character" and prop.value:
+                chars = prop.value.splitlines()
+                break
+
+        if not chars:
+            if self.lang is None or self.lang not in _REC_DICT_URLS:
+                raise ValueError(
+                    "Cannot resolve a character dictionary: the ONNX graph has "
+                    "no 'character' metadata and the recognizer language is "
+                    f"unknown ({self.lang!r})."
+                )
+            dict_path = _fetch_onnx(_REC_DICT_URLS[self.lang], f"{self.lang}_dict.txt")
+            with open(dict_path, encoding="utf-8") as handle:
+                chars = handle.read().splitlines()
+
+        self._charlist = ["<blank>", *chars, " "]
+        return self._charlist
+
+    def forward(self, image: torch.Tensor) -> torch.Tensor:
+        """
+        Run text recognition on a text-line crop and produce CTC logits.
+
+        Parameters
+        ----------
+        image
+            Pixel values pre-processed for recognizer consumption.
+            Range: float[0, 1]
+            3-channel Color Space: RGB
+
+        Returns
+        -------
+        logits : torch.Tensor
+            CTC logits over the character dictionary. Shape [batch, T, vocab].
+        """
+        return super().forward(image)
+
+    def get_input_spec(
+        self,
+        batch_size: int = 1,
+        height: int = RECOGNITION_HEIGHT,
+        width: int = RECOGNITION_WIDTH,
+    ) -> InputSpec:
+        return {
+            "image": TensorSpec(
+                shape=(batch_size, 3, height, width),
+                dtype="float32",
+                io_type=IoType.IMAGE,
+                value_range=(0.0, 1.0),
+                image_metadata=ImageMetadata(
+                    color_format=ColorFormat.RGB,
+                ),
+            ),
+        }
+
+    def get_output_names(self) -> list[str]:
+        return ["logits"]
+
+    def get_channel_last_inputs(self) -> list[str]:
+        return ["image"]
+
+
+@CollectionModel.add_component(PPOCRv5Detector, "det")
+@CollectionModel.add_component(PPOCRv5Recognizer, "zh_rec")
+@CollectionModel.add_component(PPOCRv5Recognizer, "ko_rec")
+@CollectionModel.add_component(PPOCRv5Recognizer, "en_rec")
+@CollectionModel.add_component(PPOCRv5Recognizer, "latin_rec")
+@CollectionModel.add_component(PPOCRv5Recognizer, "eslav_rec")
+@CollectionModel.add_component(PPOCRv5Recognizer, "thai_rec")
+@CollectionModel.add_component(PPOCRv5Recognizer, "greek_rec")
+class PPOCRv5(PretrainedCollectionModel):
+    """PP-OCRv5 detection + multilingual recognition collection.
+
+    A shared text detector plus the seven PP-OCRv5 recognition languages,
+    each an independently-compiled component:
+        * det       : text detection (PP-HGNetV2 + DB++)
+        * zh_rec    : Simplified Chinese + English recognition (SVTR/CTC)
+        * ko_rec    : Korean + English recognition (SVTR/CTC)
+        * en_rec    : English recognition (SVTR/CTC)
+        * latin_rec : Latin-script recognition (SVTR/CTC)
+        * eslav_rec : Cyrillic / East-Slavic recognition (SVTR/CTC)
+        * thai_rec  : Thai recognition (SVTR/CTC)
+        * greek_rec : Greek recognition (SVTR/CTC)
+    """
+
+    def __init__(
+        self,
+        det: PPOCRv5Detector,
+        zh_rec: PPOCRv5Recognizer,
+        ko_rec: PPOCRv5Recognizer,
+        en_rec: PPOCRv5Recognizer,
+        latin_rec: PPOCRv5Recognizer,
+        eslav_rec: PPOCRv5Recognizer,
+        thai_rec: PPOCRv5Recognizer,
+        greek_rec: PPOCRv5Recognizer,
+    ) -> None:
+        super().__init__(
+            det,
+            zh_rec,
+            ko_rec,
+            en_rec,
+            latin_rec,
+            eslav_rec,
+            thai_rec,
+            greek_rec,
+        )
+        self.det = det
+        self.zh_rec = zh_rec
+        self.ko_rec = ko_rec
+        self.en_rec = en_rec
+        self.latin_rec = latin_rec
+        self.eslav_rec = eslav_rec
+        self.thai_rec = thai_rec
+        self.greek_rec = greek_rec
+
+    @classmethod
+    def from_pretrained(cls) -> Self:
+        return cls(
+            PPOCRv5Detector.from_pretrained(),
+            PPOCRv5Recognizer.from_pretrained("zh"),
+            PPOCRv5Recognizer.from_pretrained("ko"),
+            PPOCRv5Recognizer.from_pretrained("en"),
+            PPOCRv5Recognizer.from_pretrained("latin"),
+            PPOCRv5Recognizer.from_pretrained("eslav"),
+            PPOCRv5Recognizer.from_pretrained("thai"),
+            PPOCRv5Recognizer.from_pretrained("greek"),
+        )

--- a/src/qai_hub_models/models/pp_ocrv5/requirements.txt
+++ b/src/qai_hub_models/models/pp_ocrv5/requirements.txt
@@ -1,0 +1,2 @@
+onnxruntime==1.22.1
+opencv-python==4.11.0.86

--- a/src/qai_hub_models/models/pp_ocrv5/test.py
+++ b/src/qai_hub_models/models/pp_ocrv5/test.py
@@ -1,0 +1,57 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+
+import numpy as np
+import torch
+
+from qai_hub_models.models.pp_ocrv5.demo import main as demo_main
+from qai_hub_models.models.pp_ocrv5.model import (
+    DETECTION_RESOLUTION,
+    RECOGNITION_HEIGHT,
+    RECOGNITION_WIDTH,
+    PPOCRv5,
+    PPOCRv5Detector,
+    PPOCRv5Recognizer,
+)
+from qai_hub_models.scorecard.utils.testing import skip_clone_repo_check
+
+
+@skip_clone_repo_check
+def test_task() -> None:
+    model = PPOCRv5.from_pretrained()
+
+    # Detection produces a per-pixel probability map.
+    height, width = DETECTION_RESOLUTION
+    det_input = torch.rand(1, 3, height, width)
+    prob_map = np.asarray(model.det(det_input))
+    assert prob_map.shape[0] == 1
+    assert prob_map.shape[1] == 1
+
+    # All recognition components produce 3D CTC logits [batch, T, vocab].
+    rec_input = torch.rand(1, 3, RECOGNITION_HEIGHT, RECOGNITION_WIDTH)
+    for recognizer in (
+        model.zh_rec,
+        model.ko_rec,
+        model.en_rec,
+        model.latin_rec,
+        model.eslav_rec,
+        model.thai_rec,
+        model.greek_rec,
+    ):
+        logits = np.asarray(recognizer(rec_input))
+        assert logits.ndim == 3
+        assert logits.shape[0] == 1
+
+
+@skip_clone_repo_check
+def test_components_load() -> None:
+    det = PPOCRv5Detector.from_pretrained()
+    assert det is not None
+    for lang in ("zh", "ko", "en", "latin", "eslav", "thai", "greek"):
+        assert PPOCRv5Recognizer.from_pretrained(lang) is not None
+
+
+def test_demo() -> None:
+    demo_main(is_test=True)

--- a/src/qai_hub_models/models/pp_ocrv5/test_generated.py
+++ b/src/qai_hub_models/models/pp_ocrv5/test_generated.py
@@ -1,0 +1,402 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2025 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+# THIS FILE WAS AUTO-GENERATED. DO NOT EDIT MANUALLY.
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from pathlib import Path
+
+import numpy as np
+import pytest
+import qai_hub as hub
+import torch
+
+import qai_hub_models.models.pp_ocrv5 as _model_module
+from qai_hub_models import Precision, TargetRuntime
+from qai_hub_models.models.pp_ocrv5 import MODEL_ID, Model
+from qai_hub_models.models.pp_ocrv5.export import (
+    compile_model,
+    export_model,
+    inference_model,
+    link_model,
+    profile_model,
+    quantize_model,
+    upload_model,
+)
+from qai_hub_models.scorecard import (
+    ScorecardCompilePath,
+    ScorecardDevice,
+    ScorecardProfilePath,
+)
+from qai_hub_models.scorecard.errors import CachedScorecardJobError
+from qai_hub_models.scorecard.execution_helpers import (
+    get_compile_parameterized_pytest_config,
+    get_evaluation_parameterized_pytest_config,
+    get_export_parameterized_pytest_config,
+    get_link_parameterized_pytest_config,
+    get_profile_parameterized_pytest_config,
+    get_quantize_parameterized_pytest_config,
+    needs_pre_quantize_compile,
+    pytest_device_idfn,
+)
+from qai_hub_models.scorecard.utils.testing import skip_invalid_runtime_device
+from qai_hub_models.scorecard.utils.testing_export_eval import (
+    accuracy_on_sample_inputs_via_export,
+    compile_via_export,
+    export_test_e2e,
+    inference_via_export,
+    link_via_export,
+    on_device_inference_for_accuracy_validation,
+    pre_quantize_compile_via_export,
+    profile_via_export,
+    quantize_via_export,
+    split_and_group_accuracy_validation_output_batches,
+    torch_inference_for_accuracy_validation,
+    torch_inference_for_accuracy_validation_outputs,
+)
+from qai_hub_models.utils.input_spec import InputSpec
+from qai_hub_models.utils.validation import perform_runtime_model_validation
+
+# All runtime + precision pairs that are enabled for testing and are compatibile with this model.
+# NOTE:
+#   Certain supported pairs may be excluded from this list if they are not enabled for testing.
+#   For example, models that allow JIT (on-device) compile will not test AOT runtimes; we assume that if it works on JIT it will work on AOT.
+ENABLED_PRECISION_RUNTIMES: dict[Precision, list[TargetRuntime]] = {
+    Precision.float: [
+        TargetRuntime.TFLITE,
+        TargetRuntime.QNN_DLC,
+        TargetRuntime.ONNX,
+    ],
+    Precision.w8a8: [
+        TargetRuntime.TFLITE,
+        TargetRuntime.QNN_DLC,
+        TargetRuntime.ONNX,
+    ],
+}
+
+
+# All runtime + precision pairs that are enabled for testing and have no known failure reasons.
+# NOTE:
+#   Certain supported pairs may be excluded from this list if they are not enabled for testing.
+#   For example, models that allow JIT (on-device) compile will not test AOT runtimes; we assume that if it works on JIT it will work on AOT.
+PASSING_PRECISION_RUNTIMES: dict[Precision, list[TargetRuntime]] = {
+    Precision.float: [
+        TargetRuntime.TFLITE,
+        TargetRuntime.QNN_DLC,
+        TargetRuntime.ONNX,
+    ],
+    Precision.w8a8: [
+        TargetRuntime.TFLITE,
+        TargetRuntime.QNN_DLC,
+        TargetRuntime.ONNX,
+    ],
+}
+
+
+EVAL_DEVICE = ScorecardDevice.get("Samsung Galaxy S25 (Family)")
+HAS_EVAL_DATASET = len(Model.get_eval_dataset_classes()) > 0
+
+
+@pytest.mark.compile
+def test_runtime_model_validation() -> None:
+    perform_runtime_model_validation(
+        Model, MODEL_ID, getattr(_model_module, "App", None)
+    )
+
+
+@pytest.mark.pre_quantize_compile
+@pytest.mark.skipif(
+    not needs_pre_quantize_compile(
+        MODEL_ID, ENABLED_PRECISION_RUNTIMES, PASSING_PRECISION_RUNTIMES
+    ),
+    reason="Model does not require pre-quantize compile step",
+)
+def test_pre_quantize_compile() -> None:
+    pre_quantize_compile_via_export(
+        compile_model,
+        MODEL_ID,
+        Model.from_pretrained(),
+        upload_model,
+    )
+
+
+@pytest.mark.parametrize(
+    "precision",
+    get_quantize_parameterized_pytest_config(
+        MODEL_ID, ENABLED_PRECISION_RUNTIMES, PASSING_PRECISION_RUNTIMES
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.quantize
+def test_quantize(precision: Precision) -> None:
+    try:
+        quantize_via_export(
+            quantize_model,
+            MODEL_ID,
+            Model.from_pretrained(),
+            precision,
+        )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+ALL_COMPONENTS = Model.component_class_names
+
+
+@pytest.mark.parametrize(
+    ("precision", "scorecard_path", "device"),
+    get_compile_parameterized_pytest_config(
+        MODEL_ID, ENABLED_PRECISION_RUNTIMES, PASSING_PRECISION_RUNTIMES
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.compile
+def test_compile(
+    precision: Precision, scorecard_path: ScorecardCompilePath, device: ScorecardDevice
+) -> None:
+    skip_invalid_runtime_device(Model, scorecard_path.runtime, device)
+    try:
+        compile_via_export(
+            compile_model,
+            MODEL_ID,
+            Model.from_pretrained(),
+            precision,
+            scorecard_path,
+            device,
+            upload_model=upload_model,
+        )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+@pytest.mark.parametrize(
+    ("precision", "scorecard_path", "device"),
+    get_link_parameterized_pytest_config(
+        MODEL_ID, ENABLED_PRECISION_RUNTIMES, PASSING_PRECISION_RUNTIMES
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.link
+def test_link(
+    precision: Precision, scorecard_path: ScorecardCompilePath, device: ScorecardDevice
+) -> None:
+    skip_invalid_runtime_device(Model, scorecard_path.runtime, device)
+    try:
+        link_via_export(
+            link_model,
+            MODEL_ID,
+            Model.from_pretrained(),
+            precision,
+            scorecard_path,
+            device,
+        )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+@pytest.mark.parametrize(
+    ("precision", "scorecard_path", "device"),
+    get_profile_parameterized_pytest_config(
+        MODEL_ID, ENABLED_PRECISION_RUNTIMES, PASSING_PRECISION_RUNTIMES
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.profile
+def test_profile(
+    precision: Precision, scorecard_path: ScorecardProfilePath, device: ScorecardDevice
+) -> None:
+    skip_invalid_runtime_device(Model, scorecard_path.runtime, device)
+    try:
+        profile_via_export(
+            profile_model,
+            MODEL_ID,
+            Model.from_pretrained(),
+            precision,
+            scorecard_path,
+            device,
+        )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+@pytest.mark.parametrize(
+    ("precision", "scorecard_path", "device"),
+    get_evaluation_parameterized_pytest_config(
+        MODEL_ID,
+        EVAL_DEVICE,
+        ENABLED_PRECISION_RUNTIMES,
+        PASSING_PRECISION_RUNTIMES,
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.inference
+def test_inference(
+    precision: Precision, scorecard_path: ScorecardProfilePath, device: ScorecardDevice
+) -> None:
+    skip_invalid_runtime_device(Model, scorecard_path.runtime, device)
+    try:
+        if HAS_EVAL_DATASET:
+            on_device_inference_for_accuracy_validation(
+                Model,
+                Model.get_eval_dataset_classes()[0],
+                MODEL_ID,
+                precision,
+                scorecard_path,
+                device,
+            )
+        else:
+            inference_via_export(
+                inference_model,
+                MODEL_ID,
+                Model.from_pretrained(),
+                precision,
+                scorecard_path,
+                device,
+            )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+@pytest.mark.inference
+def test_val_data_torch() -> None:
+    if not HAS_EVAL_DATASET:
+        return
+    torch_inference_for_accuracy_validation(
+        Model.from_pretrained(), Model.get_eval_dataset_classes()[0], MODEL_ID
+    )
+
+
+@pytest.fixture(scope="module")
+def torch_val_outputs() -> list[np.ndarray]:
+    """
+    Because the below method downloads a dataset over the internet,
+    it is called in a fixture so it can be reused.
+    """
+    if not HAS_EVAL_DATASET:
+        return []
+    return torch_inference_for_accuracy_validation_outputs(MODEL_ID)
+
+
+@pytest.fixture(scope="module")
+def torch_evaluate_mock_outputs(
+    torch_val_outputs: list[np.ndarray],
+) -> list[torch.Tensor | tuple[torch.Tensor, ...]]:
+    """
+    Because the below method does some memory movement,
+    it is called in a fixture so its output can be reused.
+    """
+    if not HAS_EVAL_DATASET:
+        return []
+    return split_and_group_accuracy_validation_output_batches(torch_val_outputs)
+
+
+@pytest.mark.parametrize(
+    ("precision", "scorecard_path", "device"),
+    get_evaluation_parameterized_pytest_config(
+        MODEL_ID,
+        EVAL_DEVICE,
+        ENABLED_PRECISION_RUNTIMES,
+        PASSING_PRECISION_RUNTIMES,
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.compute_device_accuracy
+def test_val_accuracy(
+    precision: Precision,
+    scorecard_path: ScorecardProfilePath,
+    device: ScorecardDevice,
+    torch_val_outputs: list[np.ndarray],
+    torch_evaluate_mock_outputs: list[torch.Tensor | tuple[torch.Tensor, ...]],
+) -> None:
+    try:
+        accuracy_on_sample_inputs_via_export(
+            export_model,
+            MODEL_ID,
+            Model.from_pretrained(),
+            precision,
+            scorecard_path,
+            device,
+        )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+@pytest.mark.parametrize(
+    ("precision", "scorecard_path", "device"),
+    get_export_parameterized_pytest_config(
+        MODEL_ID,
+        EVAL_DEVICE,
+        ENABLED_PRECISION_RUNTIMES,
+        PASSING_PRECISION_RUNTIMES,
+    ),
+    ids=pytest_device_idfn,
+)
+@pytest.mark.export
+def test_export(
+    precision: Precision, scorecard_path: ScorecardProfilePath, device: ScorecardDevice
+) -> None:
+    skip_invalid_runtime_device(Model, scorecard_path.runtime, device)
+    try:
+        export_test_e2e(
+            export_model,
+            Model,
+            MODEL_ID,
+            precision,
+            scorecard_path,
+            device,
+            ALL_COMPONENTS,
+        )
+    except CachedScorecardJobError as e:
+        pytest.skip(str(e))
+
+
+# Cache serialize() and hub.upload_model() across the module so the same
+# (component, graph, input_spec) is serialized once and the resulting bytes are
+# uploaded once -- matters most for multi-GB AIMET LLM bundles.
+@pytest.fixture(scope="module", autouse=True)
+def cached_serialize_for_export(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[pytest.MonkeyPatch, None, None]:
+    cache_dir = tmp_path_factory.mktemp("serialize_cache")
+    with pytest.MonkeyPatch.context() as mp:
+        model_cache: dict[str, Path] = {}
+        upload_cache: dict[str, hub.Model] = {}
+
+        real_upload_model = hub.upload_model
+
+        def _cached_upload_model(
+            model: hub.client.SourceModel | str,
+            name: str | None = None,
+            project: str | hub.client.Project | None = None,
+        ) -> hub.Model:
+            key = str(model)
+            cached = upload_cache.get(key)
+            if cached is None:
+                cached = real_upload_model(model, name, project)
+                upload_cache[key] = cached
+            return cached
+
+        mp.setattr(hub, "upload_model", _cached_upload_model)
+        serialize_component = Model.serialize_component
+
+        def _cached_serialize_component(
+            self: Model,
+            component_name: str,
+            output_dir: str | os.PathLike,
+            input_spec: InputSpec | None = None,
+        ) -> Path:
+            model_key = component_name + str(input_spec)
+            cached = model_cache.get(model_key)
+            if not cached:
+                cached = serialize_component(
+                    self, component_name, cache_dir, input_spec
+                )
+                model_cache[model_key] = cached
+            return cached
+
+        mp.setattr(Model, "serialize_component", _cached_serialize_component)
+        yield mp


### PR DESCRIPTION
Adds **pp_ocrv5** — PaddleOCR v5 text detection + recognition for 7 v5 languages (Chinese/Japanese, Korean, English, Latin, Cyrillic, Thai, Greek), Apache-2.0, as a collection model. The source is ONNX, so the components override `serialize()` to provide the ONNX graph directly to AI Hub (same approach as `pi05`) instead of torch-tracing.

**AI Hub validated** on Samsung Galaxy S25 Ultra (compile + profile): float TFLite, 100% NPU — det **1.54 ms**, ko_rec **4.39 ms**, zh_rec **10.84 ms**. Accuracy on ReCTS real signage (n=200): 48.5% full-string recall, 66.0% per-char recall. int8 (w8a8) quantization with a calibration set further reduces latency to ~1.2/1.0/0.5 ms.

`perf.yaml`/`release-assets.yaml` omitted (scorecard/release CI generates them).