### PR TITLE
Fix RoPE scaling factor propagation in Genie config

### DIFF
--- a/src/qai_hub_models/models/templates/llm/llm_helpers.py
+++ b/src/qai_hub_models/models/templates/llm/llm_helpers.py
@@ -273,7 +273,7 @@ def create_genie_config(
                 "rope-theta": int(get_rope_theta(llm_config)),
                 "rope-scaling": {
                     "rope-type": rope_scaling["rope_type"],
-                    "factor": 8.0,
+                    "factor": rope_scaling.get("factor", 8.0),
                     "low-freq-factor": rope_scaling["low_freq_factor"],
                     "high-freq-factor": rope_scaling["high_freq_factor"],
                     "original-max-position-embeddings": rope_scaling[

--- a/src/qai_hub_models/models/templates/llm/test_llm_helpers.py
+++ b/src/qai_hub_models/models/templates/llm/test_llm_helpers.py
@@ -1,0 +1,39 @@
+# ---------------------------------------------------------------------
+# Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+# ---------------------------------------------------------------------
+from types import SimpleNamespace
+
+from qai_hub_models.models.templates.llm.llm_helpers import create_genie_config
+
+
+def test_create_genie_config_preserves_rope_scaling_factor() -> None:
+    rope_scaling = {
+        "rope_type": "llama3",
+        "factor": 32.0,
+        "low_freq_factor": 1.0,
+        "high_freq_factor": 4.0,
+        "original_max_position_embeddings": 8192,
+    }
+    llm_config = SimpleNamespace(
+        hidden_size=2048,
+        num_attention_heads=32,
+        vocab_size=128256,
+        bos_token_id=128000,
+        eos_token_id=[128001, 128008, 128009],
+        rope_theta=500000,
+        rope_scaling=rope_scaling,
+    )
+
+    genie_config = create_genie_config(
+        context_length=1024,
+        llm_config=llm_config,
+        embedding_type="rope",
+        model_list=["part1.bin", "part2.bin", "part3.bin"],
+    )
+
+    output_factor = genie_config["dialog"]["engine"]["model"]["positional-encoding"][
+        "rope-scaling"
+    ]["factor"]
+
+    assert output_factor == rope_scaling["factor"]


### PR DESCRIPTION
## Summary

Propagate the model-provided RoPE scaling factor into the generated Genie config instead of always hardcoding `8.0`.

This preserves the existing fallback behavior when `factor` is absent while allowing models such as Llama 3.2 to emit their configured value, such as `32.0`.

This addresses the Genie config RoPE scaling factor propagation reported in #337. It does not attempt to address the separate v68 compile/runtime degeneration described in that issue.

## Changes

* Replace the hardcoded Genie RoPE scaling factor:

  * from `8.0`
  * to `rope_scaling.get("factor", 8.0)`
* Preserve backward compatibility by keeping `8.0` as the fallback when `factor` is not provided.
* Add a regression test verifying that the configured RoPE scaling factor is preserved in the generated Genie config.

## Test Plan

Ran the targeted regression test:

```text
python -m pytest \
  src/qai_hub_models/models/templates/llm/test_llm_helpers.py
  -v

1 passed in 0.05s
```

Additional validation:

```text
git diff --check
```

passed.

Pre-commit results:

* license check: passed
* YAML check: passed
* trailing whitespace check: passed
* merge conflict check: passed
* AWS credential detection: passed
* GitHub Actions lint: passed
* shellcheck: passed
* Ruff checks: passed
* Ruff formatting: passed
* pydoclint: passed

The full-repository `mypy` hooks run successfully but report existing type-checking errors in unrelated files across the repository. No reported `mypy` errors are in the files changed by this PR.

Related to #337.