### PR TITLE
Fix incorrect epsilon argument forwarding in compare_psnr

### DIFF
--- a/src/qai_hub_models/utils/compare.py
+++ b/src/qai_hub_models/utils/compare.py
@@ -137,7 +137,7 @@ def compare_psnr(
     eps2: float = 1e-10,
 ) -> None:
     """Raises an error if the PSNR between two tensors is below a threshold."""
-    psnr = compute_psnr(output_a, output_b, eps, eps2)
+    psnr = compute_psnr(output_a, output_b, eps=eps, eps2=eps2)
     assert psnr > psnr_threshold
 
 

--- a/src/qai_hub_models/utils/test_compare.py
+++ b/src/qai_hub_models/utils/test_compare.py
@@ -4,13 +4,42 @@
 # ---------------------------------------------------------------------
 
 import numpy as np
+import pytest
+import torch
 
 from qai_hub_models.utils.compare import (
+    compare_psnr,
     compute_mae,
     compute_max_abs_diff,
     compute_mse,
     compute_top_k_accuracy,
 )
+
+
+@pytest.mark.parametrize("as_tensor", [False, True])
+def test_compare_psnr(as_tensor: bool) -> None:
+    a = np.array([0.999], dtype=np.float32)
+    b = np.array([1.0], dtype=np.float32)
+    output_a = torch.from_numpy(a) if as_tensor else a
+    output_b = torch.from_numpy(b) if as_tensor else b
+
+    # Automatic data-range estimation gives approximately 60 dB.
+    compare_psnr(output_a, output_b, psnr_threshold=30)
+    with pytest.raises(AssertionError):
+        compare_psnr(output_a, output_b, psnr_threshold=70)
+
+
+@pytest.mark.parametrize("as_tensor", [False, True])
+def test_compare_psnr_custom_epsilons(as_tensor: bool) -> None:
+    a = np.array([0.9], dtype=np.float32)
+    b = np.array([1.0], dtype=np.float32)
+    output_a = torch.from_numpy(a) if as_tensor else a
+    output_b = torch.from_numpy(b) if as_tensor else b
+
+    # PSNR = 20 * log10((1 + 0.5) / (0.1 + 0.1)), approximately 17.5 dB.
+    compare_psnr(output_a, output_b, psnr_threshold=17, eps=0.5, eps2=0.1)
+    with pytest.raises(AssertionError):
+        compare_psnr(output_a, output_b, psnr_threshold=18, eps=0.5, eps2=0.1)
 
 
 def test_compute_mse() -> None:


### PR DESCRIPTION
Fixes #341

## Summary

`compare_psnr` forwards epsilon arguments positionally, binding them to `data_range` and `eps` instead of `eps` and `eps2`. This can incorrectly reject nearly identical outputs: approximately 60 dB PSNR becomes -40 dB.

- Forward `eps` and `eps2` by keyword, preserving automatic data-range estimation.
- Add regression coverage for NumPy arrays and Torch tensors, including custom epsilon values and passing/failing thresholds.

## Test Plan

- Confirmed all four new regression cases fail before the fix.
- Ran `pytest src/qai_hub_models/utils/test_compare.py -q`: all 8 tests pass.
- Ran all applicable pre-commit hooks on both changed files:
  Ruff lint/format, mypy, pydoclint and file checks pass.
- Separate line-ending checks and `git diff --check` pass.